### PR TITLE
Add config option to customize the polling interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 12. Click the `Add Integration` button
 13. Search the list for `generac` and select it
 14. Enter the credentials you use to login for https://app.mobilelinkgen.com/ and submit the form
-15. The integration should initialize and begin pulling your device information within seconds 
+15. The integration should initialize and begin pulling your device information within seconds
 
 ## Installation (without HACS)
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,6 @@
 14. Enter the credentials you use to login for https://app.mobilelinkgen.com/ and submit the form
 15. The integration should initialize and begin pulling your device information within seconds 
 
-
 ## Installation (without HACS)
 
 1. Using the tool of choice open the directory (folder) for your HA configuration (where you find `configuration.yaml`).

--- a/custom_components/generac/__init__.py
+++ b/custom_components/generac/__init__.py
@@ -21,7 +21,6 @@ from .const import PLATFORMS
 from .const import STARTUP_MESSAGE
 from .coordinator import GeneracDataUpdateCoordinator
 
-SCAN_INTERVAL = timedelta(seconds=30)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 

--- a/custom_components/generac/__init__.py
+++ b/custom_components/generac/__init__.py
@@ -6,7 +6,6 @@ https://github.com/bentekkie/generac
 """
 import asyncio
 import logging
-from datetime import timedelta
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant

--- a/custom_components/generac/config_flow.py
+++ b/custom_components/generac/config_flow.py
@@ -11,7 +11,7 @@ from .api import InvalidCredentialsException
 from .const import CONF_PASSWORD
 from .const import CONF_USERNAME
 from .const import DOMAIN
-from .const import PLATFORMS
+from .const import CONF_OPTIONS
 
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
@@ -102,8 +102,10 @@ class GeneracOptionsFlowHandler(config_entries.OptionsFlow):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(x, default=self.options.get(x, True)): bool
-                    for x in sorted(PLATFORMS)
+                    vol.Required(k, default=self.options.get(k, v["default"])): v[
+                        "type"
+                    ]
+                    for k, v in CONF_OPTIONS.items()
                 }
             ),
         )

--- a/custom_components/generac/config_flow.py
+++ b/custom_components/generac/config_flow.py
@@ -8,10 +8,10 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 
 from .api import GeneracApiClient
 from .api import InvalidCredentialsException
+from .const import CONF_OPTIONS
 from .const import CONF_PASSWORD
 from .const import CONF_USERNAME
 from .const import DOMAIN
-from .const import CONF_OPTIONS
 
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)

--- a/custom_components/generac/const.py
+++ b/custom_components/generac/const.py
@@ -12,6 +12,11 @@ ATTRIBUTION = (
 )
 ISSUE_URL = "https://github.com/binarydev/ha-generac/issues"
 
+
+# Defaults
+DEFAULT_NAME = DOMAIN
+DEFAULT_SCAN_INTERVAL = 30
+
 # Platforms
 BINARY_SENSOR = "binary_sensor"
 SENSOR = "sensor"
@@ -19,15 +24,20 @@ WEATHER = "weather"
 IMAGE = "image"
 PLATFORMS = [BINARY_SENSOR, SENSOR, WEATHER, IMAGE]
 
-
 # Configuration and options
 CONF_ENABLED = "enabled"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"
+CONF_SCAN_INTERVAL = "scan_interval"
 
-# Defaults
-DEFAULT_NAME = DOMAIN
-
+# Options
+bool_opts = {}
+for p in PLATFORMS:
+    bool_opts[p] = {"type": bool, "default": True}
+CONF_OPTIONS = {
+    **bool_opts,
+    CONF_SCAN_INTERVAL: {"type": int, "default": DEFAULT_SCAN_INTERVAL},
+}
 
 STARTUP_MESSAGE = f"""
 -------------------------------------------------------------------

--- a/custom_components/generac/coordinator.py
+++ b/custom_components/generac/coordinator.py
@@ -8,9 +8,10 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .api import GeneracApiClient
 from .const import DOMAIN
+from .const import CONF_SCAN_INTERVAL
+from .const import DEFAULT_SCAN_INTERVAL
 from .models import Item
 
-SCAN_INTERVAL = timedelta(seconds=30)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
 
@@ -27,8 +28,10 @@ class GeneracDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Item]]):
         self._config_entry = config_entry
         self.platforms = []
         self.is_online = False
-
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=SCAN_INTERVAL)
+        scan_interval = timedelta(
+            seconds=config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        )
+        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=scan_interval)
 
     async def _async_update_data(self):
         """Update data via library."""

--- a/custom_components/generac/coordinator.py
+++ b/custom_components/generac/coordinator.py
@@ -7,9 +7,9 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .api import GeneracApiClient
-from .const import DOMAIN
 from .const import CONF_SCAN_INTERVAL
 from .const import DEFAULT_SCAN_INTERVAL
+from .const import DOMAIN
 from .models import Item
 
 

--- a/custom_components/generac/translations/en.json
+++ b/custom_components/generac/translations/en.json
@@ -24,6 +24,7 @@
         "data": {
           "binary_sensor": "Binary sensor enabled",
           "image": "Image enabled",
+          "scan_interval": "Polling interval (seconds)",
           "sensor": "Sensor enabled",
           "switch": "Switch enabled",
           "weather": "Weather sensor enabled"

--- a/custom_components/generac/translations/fr.json
+++ b/custom_components/generac/translations/fr.json
@@ -23,6 +23,7 @@
         "data": {
           "binary_sensor": "Capteur binaire activé",
           "image": "Image activé",
+          "scan_interval": "Intervalle d’interrogation en secondes",
           "sensor": "Capteur activé",
           "switch": "Interrupteur activé",
           "weather": "Capteur météo activé"

--- a/custom_components/generac/translations/nb.json
+++ b/custom_components/generac/translations/nb.json
@@ -23,6 +23,7 @@
         "data": {
           "binary_sensor": "Binær sensor aktivert",
           "image": "Bilde aktivert",
+          "scan_interval": "Avstemningsintervall i sekunder",
           "sensor": "Sensor aktivert",
           "switch": "Bryter aktivert",
           "weather": "Værsensor aktivert"


### PR DESCRIPTION
Allow polling interval to be configurable with a default of 30 seconds. Directly addresses a feature request from @mikesalz in an open issue on the original repo (found here: https://github.com/bentekkie/ha-generac/issues/37).

To be released in v0.1.2