### PR TITLE
Add propane tank monitor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,14 @@
 
 **Custom Generac integration component with support for generators and propane tank monitors. It will set up the following platforms.**
 
-| Platform        | Entities created for each generator                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------- |
-| `binary_sensor` | `is_connected`, `is_connecting`, `has_maintenance_alert`, `has_warning`                                       |
+| Platform        | Entities created for each generator                                                                                                                                                                                                                                               |
+| --------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `binary_sensor` | `is_connected`, `is_connecting`, `has_maintenance_alert`, `has_warning`                                                                                                                                                                                                           |
 | `sensor`        | `status`, `run_time`, `protection_time`, `activation_date`, `last_seen`, `connection_time`, `battery_voltage`, `device_type`, `dealer_email`, `dealer_name`, `dealer_phone`, `address`, `status_text`, `status_label`, `serial_number`, `model_number`, `device_ssid`, `panel_id` |
 
-| Platform        | Entities created for each propane tank monitor                                                                           |
-| --------------- | ------------------------------------------------------------------------------------------------------------- |
-| `binary_sensor` | `is_connected`, `is_connecting`, `has_maintenance_alert`, `has_warning`                                       |
+| Platform        | Entities created for each propane tank monitor                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `binary_sensor` | `is_connected`, `is_connecting`, `has_maintenance_alert`, `has_warning`                                                        |
 | `sensor`        | `status`, `capacity`, `fuel_level`, `fuel_type`, `orientation`, `last_reading_date`, `battery_level`, `address`, `device_type` |
 
 ![example][exampleimg]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 [![hacs][hacsbadge]][hacs]
 
-**This component will set up the following platforms.**
+**Custom Generac integration component with support for generators and propane tank monitors. It will set up the following platforms.**
 
 | Platform        | Entities created for each generator                                                                           |
 | --------------- | ------------------------------------------------------------------------------------------------------------- |
 | `binary_sensor` | `is_connected`, `is_connecting`, `has_maintenance_alert`, `has_warning`                                       |
-| `sensor`        | `status`, `run_time`, `protection_time`, `activation_date`, `last_seen`, `connection_time`, `battery_voltage` |
+| `sensor`        | `status`, `run_time`, `protection_time`, `activation_date`, `last_seen`, `connection_time`, `battery_voltage`, `device_type`, `dealer_email`, `dealer_name`, `dealer_phone`, `address`, `status_text`, `status_label`, `serial_number`, `model_number`, `device_ssid`, `panel_id` |
+
+| Platform        | Entities created for each propane tank monitor                                                                           |
+| --------------- | ------------------------------------------------------------------------------------------------------------- |
+| `binary_sensor` | `is_connected`, `is_connecting`, `has_maintenance_alert`, `has_warning`                                       |
+| `sensor`        | `status`, `capacity`, `fuel_level`, `fuel_type`, `orientation`, `last_reading_date`, `battery_level`, `address`, `device_type` |
 
 ![example][exampleimg]
 

--- a/custom_components/generac/api.py
+++ b/custom_components/generac/api.py
@@ -61,100 +61,13 @@ class GeneracApiClient:
         return await self.get_device_data()
 
     async def get_device_data(self):
-        # apparatuses = await self.get_endpoint("/v2/Apparatus/list")
-        # if apparatuses is None:
-        #     _LOGGER.debug("Could not decode apparatuses response")
-        #     return None
-        # if not isinstance(apparatuses, list):
-        #     _LOGGER.error("Expected list from /v2/Apparatus/list got %s", apparatuses)
-        apparatuses = json.loads(
-            """
-                [
-                {
-                "apparatusId":1135681,
-                "serialNumber":null,
-                "name":"500",
-                "type":2,
-                "localizedAddress":"3 some Road, binghamton, NY, 13901",
-                "materialDescription":null,
-                "heroImageUrl":null,
-                "apparatusStatus":0,
-                "isConnected":true,
-                "isConnecting":false,
-                "showWarning":false,
-                "weather":null,
-                "preferredDealerName":null,
-                "preferredDealerPhone":null,
-                "preferredDealerEmail":null,
-                "isDealerManaged":false,
-                "isDealerUnmonitored":false,
-                "modelNumber":null,
-                "panelId":null,
-                "properties":[
-                {
-                "name":"Subscriptions/apparatuses/1135681/SubscriptionsPremium",
-                "value":{
-                "type":2,
-                "status":1,
-                "isLegacy":false,
-                "isDunning":false
-                },
-                "type":2
-                },
-                {
-                "name":"Device",
-                "value":{
-                "deviceId":"002c00123036323316473134",
-                "deviceType":"lte-tankutility-v2",
-                "signalStrength":null,
-                "batteryLevel":"good",
-                "status":"Online",
-                "networkType":"lte-tankutility-v2"
-                },
-                "type":3
-                },
-                {
-                "name":"FuelType",
-                "value":"Propane",
-                "type":0
-                },
-                {
-                "name":"Orientation",
-                "value":"horizontal",
-                "type":0
-                },
-                {
-                "name":"Capacity",
-                "value":"500",
-                "type":0
-                },
-                {
-                "name":"ConsumptionTypes",
-                "value":null,
-                "type":0
-                },
-                {
-                "name":"FuelDealerId",
-                "value":"-MTlVxCs0HvpbVcoa1_E",
-                "type":0
-                },
-                {
-                "name":"LastReading",
-                "value":"2023-12-21T15:47:23Z",
-                "type":0
-                },
-                {
-                "name":"FuelLevel",
-                "value":74,
-                "type":0
-                }
-                ],
-                "values":null,
-                "provisioned":"2022-08-14T19:06:58.8861501Z"
-                }
-                ]
-            """
-        )
+        apparatuses = await self.get_endpoint("/v2/Apparatus/list")
+        if apparatuses is None:
+            _LOGGER.debug("Could not decode apparatuses response")
+            return None
+        if not isinstance(apparatuses, list):
+            _LOGGER.error("Expected list from /v2/Apparatus/list got %s", apparatuses)
+
         data: dict[str, Item] = {}
         for apparatus in apparatuses:
             apparatus = from_dict(Apparatus, apparatus)
@@ -163,14 +76,11 @@ class GeneracApiClient:
                     "Unknown apparatus type %s %s", apparatus.type, apparatus.name
                 )
                 continue
-            # detail_json = await self.get_endpoint(
-            #     f"/v1/Apparatus/details/{apparatus.apparatusId}"
-            # )
-            detail_json = json.loads(
-                """
-                {"apparatusId": 1135681, "name": "70 Birch Standby", "serialNumber": "3013639157", "apparatusClassification": 0, "panelId": "21", "activationDate": "2023-08-09T00:00:00Z", "deviceType": "wifi", "deviceSsid": "MLG45478", "shortDeviceId": null, "networkType": "wifi", "apparatusStatus": 1, "heroImageUrl": "https://soa.generac.com/selfhelp/media/6af4702c-b653-4abb-988d-efc4e67c2413", "statusLabel": "Ready to run", "statusText": "Your generator is ready to run.", "eCodeLabel": null, "weather": {"temperature": {"value": 42.0, "unit": "F", "unitType": 18}, "iconCode": 7}, "isConnected": true, "isConnecting": false, "showWarning": false, "hasMaintenanceAlert": false, "lastSeen": "2023-12-25T04:26:07.475+00:00", "connectionTimestamp": "2023-12-19T00:11:49.061+00:00", "address": {"line1": "70 Birch St", "line2": null, "city": "Kenilworth", "region": "NJ", "country": "US", "postalCode": "07033-1507"}, "properties": [{"name": null, "value": 1, "type": 70}, {"name": null, "value": "105", "type": 93}, {"name": null, "value": "13.6", "type": 69}, {"name": "Hours of Protection", "value": 3312.0, "type": 31}], "tuProperties": [], "subscription": {"type": 2, "status": 1, "isLegacy": false, "isDunning": false}, "enrolledInVpp": false, "hasActiveVppEvent": false, "productInfo": [{"name": "ProductType", "value": "gs", "type": 0}, {"name": "Description", "value": "18KW GUARDIAN-NO T/SW AL", "type": 0}], "disconnectedNotification": {"id": 20280746, "receiveEmail": true, "receiveSms": true, "receivePush": true, "snoozeUntil": null}, "hasDisconnectedNotificationsOn": true}
-            """
+
+            detail_json = await self.get_endpoint(
+                f"/v1/Apparatus/details/{apparatus.apparatusId}"
             )
+
             if detail_json is None:
                 _LOGGER.debug(
                     f"Could not decode respose from /v1/Apparatus/details/{apparatus.apparatusId}"
@@ -200,10 +110,10 @@ class GeneracApiClient:
             data = await response.json()
             _LOGGER.debug("getEndpoint %s", json.dumps(data))
             return data
-        except SessionExpiredException as ex1:
-            raise ex1
-        except Exception as ex2:
-            raise IOError() from ex2
+        except SessionExpiredException:
+            raise
+        except Exception as ex:
+            raise IOError() from ex
 
     async def login(self) -> None:
         """Login to API"""

--- a/custom_components/generac/api.py
+++ b/custom_components/generac/api.py
@@ -61,13 +61,100 @@ class GeneracApiClient:
         return await self.get_device_data()
 
     async def get_device_data(self):
-        apparatuses = await self.get_endpoint("/v2/Apparatus/list")
-        if apparatuses is None:
-            _LOGGER.debug("Could not decode apparatuses response")
-            return None
-        if not isinstance(apparatuses, list):
-            _LOGGER.error("Expected list from /v2/Apparatus/list got %s", apparatuses)
-
+        # apparatuses = await self.get_endpoint("/v2/Apparatus/list")
+        # if apparatuses is None:
+        #     _LOGGER.debug("Could not decode apparatuses response")
+        #     return None
+        # if not isinstance(apparatuses, list):
+        #     _LOGGER.error("Expected list from /v2/Apparatus/list got %s", apparatuses)
+        apparatuses = json.loads(
+            """
+                [
+                {
+                "apparatusId":1135681,
+                "serialNumber":null,
+                "name":"500",
+                "type":2,
+                "localizedAddress":"3 some Road, binghamton, NY, 13901",
+                "materialDescription":null,
+                "heroImageUrl":null,
+                "apparatusStatus":0,
+                "isConnected":true,
+                "isConnecting":false,
+                "showWarning":false,
+                "weather":null,
+                "preferredDealerName":null,
+                "preferredDealerPhone":null,
+                "preferredDealerEmail":null,
+                "isDealerManaged":false,
+                "isDealerUnmonitored":false,
+                "modelNumber":null,
+                "panelId":null,
+                "properties":[
+                {
+                "name":"Subscriptions/apparatuses/1135681/SubscriptionsPremium",
+                "value":{
+                "type":2,
+                "status":1,
+                "isLegacy":false,
+                "isDunning":false
+                },
+                "type":2
+                },
+                {
+                "name":"Device",
+                "value":{
+                "deviceId":"002c00123036323316473134",
+                "deviceType":"lte-tankutility-v2",
+                "signalStrength":null,
+                "batteryLevel":"good",
+                "status":"Online",
+                "networkType":"lte-tankutility-v2"
+                },
+                "type":3
+                },
+                {
+                "name":"FuelType",
+                "value":"Propane",
+                "type":0
+                },
+                {
+                "name":"Orientation",
+                "value":"horizontal",
+                "type":0
+                },
+                {
+                "name":"Capacity",
+                "value":"500",
+                "type":0
+                },
+                {
+                "name":"ConsumptionTypes",
+                "value":null,
+                "type":0
+                },
+                {
+                "name":"FuelDealerId",
+                "value":"-MTlVxCs0HvpbVcoa1_E",
+                "type":0
+                },
+                {
+                "name":"LastReading",
+                "value":"2023-12-21T15:47:23Z",
+                "type":0
+                },
+                {
+                "name":"FuelLevel",
+                "value":74,
+                "type":0
+                }
+                ],
+                "values":null,
+                "provisioned":"2022-08-14T19:06:58.8861501Z"
+                }
+                ]
+            """
+        )
         data: dict[str, Item] = {}
         for apparatus in apparatuses:
             apparatus = from_dict(Apparatus, apparatus)
@@ -76,15 +163,23 @@ class GeneracApiClient:
                     "Unknown apparatus type %s %s", apparatus.type, apparatus.name
                 )
                 continue
-            detail_json = await self.get_endpoint(
-                f"/v1/Apparatus/details/{apparatus.apparatusId}"
+            # detail_json = await self.get_endpoint(
+            #     f"/v1/Apparatus/details/{apparatus.apparatusId}"
+            # )
+            detail_json = json.loads(
+                """
+                {"apparatusId": 1135681, "name": "70 Birch Standby", "serialNumber": "3013639157", "apparatusClassification": 0, "panelId": "21", "activationDate": "2023-08-09T00:00:00Z", "deviceType": "wifi", "deviceSsid": "MLG45478", "shortDeviceId": null, "networkType": "wifi", "apparatusStatus": 1, "heroImageUrl": "https://soa.generac.com/selfhelp/media/6af4702c-b653-4abb-988d-efc4e67c2413", "statusLabel": "Ready to run", "statusText": "Your generator is ready to run.", "eCodeLabel": null, "weather": {"temperature": {"value": 42.0, "unit": "F", "unitType": 18}, "iconCode": 7}, "isConnected": true, "isConnecting": false, "showWarning": false, "hasMaintenanceAlert": false, "lastSeen": "2023-12-25T04:26:07.475+00:00", "connectionTimestamp": "2023-12-19T00:11:49.061+00:00", "address": {"line1": "70 Birch St", "line2": null, "city": "Kenilworth", "region": "NJ", "country": "US", "postalCode": "07033-1507"}, "properties": [{"name": null, "value": 1, "type": 70}, {"name": null, "value": "105", "type": 93}, {"name": null, "value": "13.6", "type": 69}, {"name": "Hours of Protection", "value": 3312.0, "type": 31}], "tuProperties": [], "subscription": {"type": 2, "status": 1, "isLegacy": false, "isDunning": false}, "enrolledInVpp": false, "hasActiveVppEvent": false, "productInfo": [{"name": "ProductType", "value": "gs", "type": 0}, {"name": "Description", "value": "18KW GUARDIAN-NO T/SW AL", "type": 0}], "disconnectedNotification": {"id": 20280746, "receiveEmail": true, "receiveSms": true, "receivePush": true, "snoozeUntil": null}, "hasDisconnectedNotificationsOn": true}
+            """
             )
             if detail_json is None:
                 _LOGGER.debug(
                     f"Could not decode respose from /v1/Apparatus/details/{apparatus.apparatusId}"
                 )
                 continue
-            detail = from_dict(ApparatusDetail, detail_json)
+            try:
+                detail = from_dict(ApparatusDetail, detail_json)
+            except Exception as ex2:
+                raise ex2
             data[str(apparatus.apparatusId)] = Item(apparatus, detail)
         return data
 
@@ -105,10 +200,10 @@ class GeneracApiClient:
             data = await response.json()
             _LOGGER.debug("getEndpoint %s", json.dumps(data))
             return data
-        except SessionExpiredException:
-            raise
-        except Exception as ex:
-            raise IOError() from ex
+        except SessionExpiredException as ex1:
+            raise ex1
+        except Exception as ex2:
+            raise IOError() from ex2
 
     async def login(self) -> None:
         """Login to API"""

--- a/custom_components/generac/api.py
+++ b/custom_components/generac/api.py
@@ -8,6 +8,7 @@ import aiohttp
 from bs4 import BeautifulSoup
 from dacite import from_dict
 
+from .const import ALLOWED_DEVICES
 from .models import Apparatus
 from .models import ApparatusDetail
 from .models import Item
@@ -70,7 +71,7 @@ class GeneracApiClient:
         data: dict[str, Item] = {}
         for apparatus in apparatuses:
             apparatus = from_dict(Apparatus, apparatus)
-            if apparatus.type != 0:
+            if apparatus.type not in ALLOWED_DEVICES:
                 _LOGGER.debug(
                     "Unknown apparatus type %s %s", apparatus.type, apparatus.name
                 )

--- a/custom_components/generac/api.py
+++ b/custom_components/generac/api.py
@@ -80,16 +80,12 @@ class GeneracApiClient:
             detail_json = await self.get_endpoint(
                 f"/v1/Apparatus/details/{apparatus.apparatusId}"
             )
-
             if detail_json is None:
                 _LOGGER.debug(
                     f"Could not decode respose from /v1/Apparatus/details/{apparatus.apparatusId}"
                 )
                 continue
-            try:
-                detail = from_dict(ApparatusDetail, detail_json)
-            except Exception as ex2:
-                raise ex2
+            detail = from_dict(ApparatusDetail, detail_json)
             data[str(apparatus.apparatusId)] = Item(apparatus, detail)
         return data
 

--- a/custom_components/generac/api.py
+++ b/custom_components/generac/api.py
@@ -57,9 +57,9 @@ class GeneracApiClient:
         except SessionExpiredException:
             self._logged_in = False
             return await self.async_get_data()
-        return await self.get_generator_data()
+        return await self.get_device_data()
 
-    async def get_generator_data(self):
+    async def get_device_data(self):
         apparatuses = await self.get_endpoint("/v2/Apparatus/list")
         if apparatuses is None:
             _LOGGER.debug("Could not decode apparatuses response")

--- a/custom_components/generac/binary_sensor.py
+++ b/custom_components/generac/binary_sensor.py
@@ -36,13 +36,17 @@ def sensors() -> Type[GeneracEntity]:
     ]
 
 
+def sensor_name(self, name_label):
+    return f"{DEFAULT_NAME}_{self.device_id}_{name_label}"
+
+
 class GeneracConnectedSensor(GeneracEntity, BinarySensorEntity):
     """generac binary_sensor class."""
 
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME}_{self.device_id}_is_connected"
+        return sensor_name(self, "is_connected")
 
     @property
     def device_class(self):
@@ -61,7 +65,7 @@ class GeneracConnectingSensor(GeneracEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME}_{self.device_id}_is_connecting"
+        return sensor_name(self, "is_connecting")
 
     @property
     def device_class(self):
@@ -80,7 +84,7 @@ class GeneracMaintenanceAlertSensor(GeneracEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME}_{self.device_id}_has_maintenance_alert"
+        return sensor_name(self, "has_maintenance_alert")
 
     @property
     def device_class(self):
@@ -99,7 +103,7 @@ class GeneracWarningSensor(GeneracEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME}_{self.device_id}_show_warning"
+        return sensor_name(self, "show_warning")
 
     @property
     def device_class(self):

--- a/custom_components/generac/binary_sensor.py
+++ b/custom_components/generac/binary_sensor.py
@@ -21,8 +21,8 @@ async def async_setup_entry(
     data = coordinator.data
     if isinstance(data, dict):
         async_add_entities(
-            sensor(coordinator, entry, generator_id, item)
-            for generator_id, item in data.items()
+            sensor(coordinator, entry, device_id, item)
+            for device_id, item in data.items()
             for sensor in sensors()
         )
 
@@ -42,7 +42,7 @@ class GeneracConnectedSensor(GeneracEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_is_connected"
+        return f"{DEFAULT_NAME}_{self.device_id}_is_connected"
 
     @property
     def device_class(self):
@@ -61,7 +61,7 @@ class GeneracConnectingSensor(GeneracEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_is_connecting"
+        return f"{DEFAULT_NAME}_{self.device_id}_is_connecting"
 
     @property
     def device_class(self):
@@ -80,7 +80,7 @@ class GeneracMaintenanceAlertSensor(GeneracEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_has_maintenance_alert"
+        return f"{DEFAULT_NAME}_{self.device_id}_has_maintenance_alert"
 
     @property
     def device_class(self):
@@ -99,7 +99,7 @@ class GeneracWarningSensor(GeneracEntity, BinarySensorEntity):
     @property
     def name(self):
         """Return the name of the binary_sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_show_warning"
+        return f"{DEFAULT_NAME}_{self.device_id}_show_warning"
 
     @property
     def device_class(self):

--- a/custom_components/generac/const.py
+++ b/custom_components/generac/const.py
@@ -12,11 +12,17 @@ ATTRIBUTION = (
 )
 ISSUE_URL = "https://github.com/binarydev/ha-generac/issues"
 
-# Allowlisted device types
+# Device types
 # 0 = generator
 # 1 = ?
 # 2 = propane tank monitor
-ALLOWED_DEVICES = [0, 2]
+DEVICE_TYPE_GENERATOR = 0
+DEVICE_TYPE_UNKNOWN = 1
+DEVICE_TYPE_PROPANE_MONITOR = 2
+DEVICE_NAME_LIST = ["Generator", "Unknown", "Propane Tank"]
+
+# Allowlisted device types
+ALLOWED_DEVICES = [DEVICE_TYPE_GENERATOR, DEVICE_TYPE_PROPANE_MONITOR]
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/generac/const.py
+++ b/custom_components/generac/const.py
@@ -12,6 +12,12 @@ ATTRIBUTION = (
 )
 ISSUE_URL = "https://github.com/binarydev/ha-generac/issues"
 
+# Allowlisted device types
+# 0 = generator
+# 1 = ?
+# 2 = subscription
+# 3 = propane monitor
+ALLOWED_DEVICES = [0, 3]
 
 # Defaults
 DEFAULT_NAME = DOMAIN
@@ -24,7 +30,7 @@ WEATHER = "weather"
 IMAGE = "image"
 PLATFORMS = [BINARY_SENSOR, SENSOR, WEATHER, IMAGE]
 
-# Configuration and options
+# Configuration labels
 CONF_ENABLED = "enabled"
 CONF_USERNAME = "username"
 CONF_PASSWORD = "password"

--- a/custom_components/generac/const.py
+++ b/custom_components/generac/const.py
@@ -15,9 +15,8 @@ ISSUE_URL = "https://github.com/binarydev/ha-generac/issues"
 # Allowlisted device types
 # 0 = generator
 # 1 = ?
-# 2 = subscription
-# 3 = propane monitor
-ALLOWED_DEVICES = [0, 3]
+# 2 = propane tank monitor
+ALLOWED_DEVICES = [0, 2]
 
 # Defaults
 DEFAULT_NAME = DOMAIN

--- a/custom_components/generac/entity.py
+++ b/custom_components/generac/entity.py
@@ -24,23 +24,23 @@ class GeneracEntity(CoordinatorEntity[GeneracDataUpdateCoordinator]):
         self,
         coordinator: GeneracDataUpdateCoordinator,
         config_entry: ConfigEntry,
-        generator_id: str,
+        device_id: str,
         item: Item,
     ):
         super().__init__(coordinator)
         self.config_entry = config_entry
-        self.generator_id = generator_id
+        self.device_id = device_id
         self.item = item
 
     @property
     def unique_id(self):
         """Return a unique ID to use for this entity."""
-        return f"{self.config_entry.entry_id}_{self.generator_id}_{self.name}"
+        return f"{self.config_entry.entry_id}_{self.device_id}_{self.name}"
 
     @property
     def device_info(self):
         return DeviceInfo(
-            identifiers={(DOMAIN, self.generator_id)},
+            identifiers={(DOMAIN, self.device_id)},
             name=self.aparatus.name,
             model=self.aparatus.modelNumber,
             manufacturer="Generac",
@@ -51,7 +51,7 @@ class GeneracEntity(CoordinatorEntity[GeneracDataUpdateCoordinator]):
         """Return the state attributes."""
         return {
             "attribution": ATTRIBUTION,
-            "id": str(self.generator_id),
+            "id": str(self.device_id),
             "integration": DOMAIN,
         }
 
@@ -78,6 +78,6 @@ class GeneracEntity(CoordinatorEntity[GeneracDataUpdateCoordinator]):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        self.item = self.coordinator.data.get(self.generator_id, _EMPTY_ITEM)
+        self.item = self.coordinator.data.get(self.device_id, _EMPTY_ITEM)
         _LOGGER.debug(f"Updated data for {self.unique_id}: {self.item}")
         self.async_write_ha_state()

--- a/custom_components/generac/image.py
+++ b/custom_components/generac/image.py
@@ -22,8 +22,8 @@ async def async_setup_entry(
     data = coordinator.data
     if isinstance(data, dict):
         async_add_entities(
-            HeroImageSensor(coordinator, entry, generator_id, item, hass)
-            for generator_id, item in data.items()
+            HeroImageSensor(coordinator, entry, device_id, item, hass)
+            for device_id, item in data.items()
         )
 
 
@@ -34,18 +34,18 @@ class HeroImageSensor(GeneracEntity, ImageEntity):
         self,
         coordinator: GeneracDataUpdateCoordinator,
         config_entry: ConfigEntry,
-        generator_id: str,
+        device_id: str,
         item: Item,
         hass: HomeAssistant,
     ):
         """Initialize device."""
-        super().__init__(coordinator, config_entry, generator_id, item)
+        super().__init__(coordinator, config_entry, device_id, item)
         ImageEntity.__init__(self, hass)
 
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_hero_image"
+        return f"{DEFAULT_NAME}_{self.device_id}_hero_image"
 
     @property
     def image_url(self):

--- a/custom_components/generac/image.py
+++ b/custom_components/generac/image.py
@@ -24,6 +24,7 @@ async def async_setup_entry(
         async_add_entities(
             HeroImageSensor(coordinator, entry, device_id, item, hass)
             for device_id, item in data.items()
+            if item.apparatusDetail.heroImageUrl is not None
         )
 
 

--- a/custom_components/generac/models.py
+++ b/custom_components/generac/models.py
@@ -150,7 +150,6 @@ class ApparatusDetail:
         name: Optional[str]
         value: Optional[str | int | float | dict]
         type: Optional[int | str]
-        # likely unnecessary ^
 
     @dataclass
     class ProductInfo:
@@ -181,6 +180,7 @@ class ApparatusDetail:
     connectionTimestamp: Optional[str] = None
     address: Optional[Address] = None
     properties: Optional[list[Property]] = None
+    tuProperties: Optional[list[Property]] = None
     subscription: Optional[Subscription] = None
     enrolledInVpp: Optional[bool] = None
     hasActiveVppEvent: Optional[bool] = None

--- a/custom_components/generac/models.py
+++ b/custom_components/generac/models.py
@@ -148,8 +148,9 @@ class ApparatusDetail:
     @dataclass
     class Property:
         name: Optional[str]
-        value: Optional[str | int | float]
-        type: Optional[int]
+        value: Optional[str | int | float | dict]
+        type: Optional[int | str]
+        # likely unnecessary ^
 
     @dataclass
     class ProductInfo:

--- a/custom_components/generac/sensor.py
+++ b/custom_components/generac/sensor.py
@@ -25,8 +25,8 @@ async def async_setup_entry(
     data = coordinator.data
     if isinstance(data, dict):
         async_add_entities(
-            sensor(coordinator, entry, generator_id, item)
-            for generator_id, item in data.items()
+            sensor(coordinator, entry, device_id, item)
+            for device_id, item in data.items()
             for sensor in sensors(item)
         )
 
@@ -87,7 +87,7 @@ class StatusSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_status"
+        return f"{DEFAULT_NAME}_{self.device_id}_status"
 
     @property
     def native_value(self):
@@ -114,7 +114,7 @@ class DeviceTypeSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_device_type"
+        return f"{DEFAULT_NAME}_{self.device_id}_device_type"
 
     @property
     def native_value(self):
@@ -141,7 +141,7 @@ class RunTimeSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_run_time"
+        return f"{DEFAULT_NAME}_{self.device_id}_run_time"
 
     @property
     def native_value(self):
@@ -166,7 +166,7 @@ class ProtectionTimeSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_protection_time"
+        return f"{DEFAULT_NAME}_{self.device_id}_protection_time"
 
     @property
     def native_value(self):
@@ -190,7 +190,7 @@ class ActivationDateSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_activation_date"
+        return f"{DEFAULT_NAME}_{self.device_id}_activation_date"
 
     @property
     def native_value(self):
@@ -209,7 +209,7 @@ class LastSeenSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_last_seen"
+        return f"{DEFAULT_NAME}_{self.device_id}_last_seen"
 
     @property
     def native_value(self):
@@ -228,7 +228,7 @@ class ConnectionTimeSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_connection_time"
+        return f"{DEFAULT_NAME}_{self.device_id}_connection_time"
 
     @property
     def native_value(self):
@@ -248,7 +248,7 @@ class BatteryVoltageSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_battery_voltage"
+        return f"{DEFAULT_NAME}_{self.device_id}_battery_voltage"
 
     @property
     def native_value(self):
@@ -272,7 +272,7 @@ class OutdoorTemperatureSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_outdoor_temperature"
+        return f"{DEFAULT_NAME}_{self.device_id}_outdoor_temperature"
 
     @property
     def native_unit_of_measurement(self):
@@ -302,7 +302,7 @@ class SerialNumberSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_serial_number"
+        return f"{DEFAULT_NAME}_{self.device_id}_serial_number"
 
     @property
     def native_value(self):
@@ -314,7 +314,7 @@ class ModelNumberSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_model_number"
+        return f"{DEFAULT_NAME}_{self.device_id}_model_number"
 
     @property
     def native_value(self):
@@ -326,7 +326,7 @@ class DeviceSsidSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_device_ssid"
+        return f"{DEFAULT_NAME}_{self.device_id}_device_ssid"
 
     @property
     def native_value(self):
@@ -338,7 +338,7 @@ class StatusLabelSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_status_label"
+        return f"{DEFAULT_NAME}_{self.device_id}_status_label"
 
     @property
     def native_value(self):
@@ -350,7 +350,7 @@ class StatusTextSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_status_text"
+        return f"{DEFAULT_NAME}_{self.device_id}_status_text"
 
     @property
     def native_value(self):
@@ -362,7 +362,7 @@ class AddressSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_address"
+        return f"{DEFAULT_NAME}_{self.device_id}_address"
 
     @property
     def native_value(self):
@@ -374,7 +374,7 @@ class DealerNameSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_dealer_name"
+        return f"{DEFAULT_NAME}_{self.device_id}_dealer_name"
 
     @property
     def native_value(self):
@@ -386,7 +386,7 @@ class DealerEmailSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_dealer_email"
+        return f"{DEFAULT_NAME}_{self.device_id}_dealer_email"
 
     @property
     def native_value(self):
@@ -398,7 +398,7 @@ class DealerPhoneSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_dealer_phone"
+        return f"{DEFAULT_NAME}_{self.device_id}_dealer_phone"
 
     @property
     def native_value(self):
@@ -410,7 +410,7 @@ class PanelIDSensor(GeneracEntity, SensorEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_panel_id"
+        return f"{DEFAULT_NAME}_{self.device_id}_panel_id"
 
     @property
     def native_value(self):
@@ -426,7 +426,7 @@ class PanelIDSensor(GeneracEntity, SensorEntity):
 #     @property
 #     def name(self):
 #         """Return the name of the sensor."""
-#         return f"{DEFAULT_NAME}_{self.generator_id}_signal_strength"
+#         return f"{DEFAULT_NAME}_{self.device_id}_signal_strength"
 
 #     @property
 #     def native_value(self):

--- a/custom_components/generac/weather.py
+++ b/custom_components/generac/weather.py
@@ -23,8 +23,8 @@ async def async_setup_entry(
     data = coordinator.data
     if isinstance(data, dict):
         async_add_entities(
-            sensor(coordinator, entry, generator_id, item)
-            for generator_id, item in data.items()
+            sensor(coordinator, entry, device_id, item)
+            for device_id, item in data.items()
             for sensor in sensors(item)
         )
 
@@ -39,7 +39,7 @@ class WeatherSensor(GeneracEntity, WeatherEntity):
     @property
     def name(self):
         """Return the name of the sensor."""
-        return f"{DEFAULT_NAME}_{self.generator_id}_weather"
+        return f"{DEFAULT_NAME}_{self.device_id}_weather"
 
     @property
     def condition(self):

--- a/custom_components/generac/weather.py
+++ b/custom_components/generac/weather.py
@@ -26,6 +26,8 @@ async def async_setup_entry(
             sensor(coordinator, entry, device_id, item)
             for device_id, item in data.items()
             for sensor in sensors(item)
+            if item.apparatus.weather is not None
+            and item.apparatus.weather.iconCode is not None
         )
 
 

--- a/local_test.py
+++ b/local_test.py
@@ -25,7 +25,7 @@ async def main():
             os.environ["GENERAC_USER"], os.environ["GENERAC_PASS"], session
         )
         await api.login()
-        print(json.dumps(await api.get_generator_data(), cls=EnhancedJSONEncoder))
+        print(json.dumps(await api.get_device_data(), cls=EnhancedJSONEncoder))
 
 
 loop = asyncio.get_event_loop()


### PR DESCRIPTION
Addresses issue #15 

Make it easier to add support for additional devices and add support for the Propane Tank Monitor, which is actually licensed from a third party (TankUtility). Use an allowlist to avoid unintentional device creation (such as for "subscription" objects). Sensor naming and prop value extraction have been centralized into central methods to simplify future updates.

Also only show the weather sensor if weather data is actually included and only display the hero image if an image url is provided.