### PR TITLE
fix(coordinator): pass config_entry to DataUpdateCoordinator on HA 2026.x+

### DIFF
--- a/custom_components/generac/coordinator.py
+++ b/custom_components/generac/coordinator.py
@@ -30,7 +30,13 @@ class GeneracDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Item]]):
         scan_interval = timedelta(
             seconds=config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         )
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=scan_interval)
+        super().__init__(
+            hass,
+            _LOGGER,
+            name=DOMAIN,
+            update_interval=scan_interval,
+            config_entry=config_entry,
+        )
 
     async def _async_update_data(self):
         """Update data via library."""


### PR DESCRIPTION
Small standalone fix - one of a few followups I'm sending alongside #267.

Newer Home Assistant versions require `config_entry` to be set on `DataUpdateCoordinator` so `async_config_entry_first_refresh` can resolve the entry. Without it, reloading after an options change throws:

```
ConfigEntryError: Detected code that uses async_config_entry_first_refresh,
which is only supported for coordinators with a config entry
```

Fix is one line in the `super().__init__` call to pass `config_entry=config_entry`.

Independent of the OAuth work - just spotted while testing options-flow reload locally on HA 2026.x.

Take it or leave it, no worries either way.
