### PR TITLE
fix: use hass.config_entries.async_reload for reload_entry on HA 2026.x+

### DIFF
--- a/custom_components/generac/__init__.py
+++ b/custom_components/generac/__init__.py
@@ -63,5 +63,4 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
     """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    await hass.config_entries.async_reload(entry.entry_id)


### PR DESCRIPTION
Another small standalone fix in the same vein as #268.

Calling `async_setup_entry` directly from `async_reload_entry` triggers an error on HA 2026.x:

```
ConfigEntryError: async_config_entry_first_refresh called when state is
ConfigEntryState.LOADED, but should only be called in state
ConfigEntryState.SETUP_IN_PROGRESS
```

Letting HA manage the reload via `hass.config_entries.async_reload(entry.entry_id)` handles the unload/setup cycle and state transitions correctly. One-line change.

Hit this every time I changed the scan_interval in the options flow.

Take it or leave it.
