### PR TITLE
feat(sensor): round battery voltage display to 1 decimal

### DIFF
--- a/custom_components/generac/sensor.py
+++ b/custom_components/generac/sensor.py
@@ -285,6 +285,7 @@ class BatteryVoltageSensor(GeneracEntity, SensorEntity):
 
     device_class = SensorDeviceClass.VOLTAGE
     native_unit_of_measurement = UnitOfElectricPotential.VOLT
+    suggested_display_precision = 1
 
     @property
     def name(self):


### PR DESCRIPTION
Tiny one-liner. The API returns battery voltage with a decimal (e.g. `13.7`), but the device page in HA rounds it to a whole number, so it shows up as:

> Battery Voltage: **14 V**

Adding `suggested_display_precision = 1` tells HA to render the value at 1 decimal in the UI while keeping whatever the API gives us in state for history/graphs:

> Battery Voltage: **13.7 V**

Last of the followups (along with #267 / #268 / #269). Take it or leave it, no worries either way.
