### PR TITLE
Fix FAILED_UNLOAD on reconfigure / reload (HA 2026.x compat)

### DIFF
--- a/custom_components/generac/__init__.py
+++ b/custom_components/generac/__init__.py
@@ -62,6 +62,5 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_reload_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Reload config entry."""
-    await async_unload_entry(hass, entry)
-    await async_setup_entry(hass, entry)
+    """Reload config entry via the HA framework so state transitions correctly."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/generac/coordinator.py
+++ b/custom_components/generac/coordinator.py
@@ -30,7 +30,13 @@ class GeneracDataUpdateCoordinator(DataUpdateCoordinator[dict[str, Item]]):
         scan_interval = timedelta(
             seconds=config_entry.options.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
         )
-        super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=scan_interval)
+        super().__init__(
+            hass,
+            _LOGGER,
+            config_entry=config_entry,
+            name=DOMAIN,
+            update_interval=scan_interval,
+        )
 
     async def _async_update_data(self):
         """Update data via library."""


### PR DESCRIPTION
## Problem

On modern HA (observed on **2026.4.4**), every reconfigure of the integration leaves the config entry stuck in `ConfigEntryState.FAILED_UNLOAD` and all entities go `unavailable`. The flow handler itself reports `Reconfigure Successful`, so it looks like the cookie update worked — but the entry's reload after the data update fails silently in the background, and HA refuses any subsequent reload of the entry until the user restarts HA.

Two independent issues stack:

### 1. `DataUpdateCoordinator` is constructed without `config_entry=`

```
homeassistant.exceptions.ConfigEntryError: Detected code that uses
  `async_config_entry_first_refresh`, which is only supported for
  coordinators with a config entry
```

`async_config_entry_first_refresh()` requires the coordinator's parent to know its associated config entry. `coordinator.py` already accepts and stores `config_entry` as `self._config_entry` but never forwards it to `super().__init__`.

### 2. `async_reload_entry` bypasses the HA state machine

```
homeassistant.exceptions.ConfigEntryError: `async_config_entry_first_refresh`
  called when config entry state is ConfigEntryState.LOADED, but should
  only be called in state ConfigEntryState.SETUP_IN_PROGRESS
```

The old `async_reload_entry` did `await async_unload_entry(...); await async_setup_entry(...)` directly. Modern HA expects reloads to go through `hass.config_entries.async_reload()` so the framework can transition the entry through `UNLOADED → SETUP_IN_PROGRESS → LOADED`. Calling `async_setup_entry` directly leaves the entry in `LOADED`, and `async_config_entry_first_refresh()` rightly rejects that.

Either issue alone is enough to brick the entry. Triggered by:
- Any reconfigure flow (e.g. cookie refresh)
- Any `entry.add_update_listener(async_reload_entry)` fire — i.e. any options change

Recovery before this patch requires a full HA restart.

## Fix

Two small, independent changes:

1. **`coordinator.py`** — forward `config_entry=config_entry` to `DataUpdateCoordinator.__init__` (single kwarg added).
2. **`__init__.py`** — `async_reload_entry` now calls `hass.config_entries.async_reload(entry.entry_id)` instead of `unload + setup` directly.

## Validation

Patched both files in-place on a working HA 2026.4.4 deployment (config entry `01KPRBJC6K3BB0MPNPCWMEX8DY`, single Generac G00723510). Before the patch: every reconfigure → `failed_unload`, entities → `unavailable`. After the patch + one HA restart to recover from a stuck `FAILED_UNLOAD`: subsequent reconfigure cycles transition cleanly from `setup_in_progress` → `loaded` and all entities stay live.

## Context

I'm running an automated cookie refresher that hits `POST /api/config/config_entries/flow?source=reconfigure` on a schedule to keep the ecobee-SSO session alive (per `#260`). That made the reload-after-reconfigure path get exercised twice a day, which is what surfaced both bugs. Other users may not have noticed yet because they only reconfigure manually and chalked the post-reload `unavailable` state up to "the cookie got rejected" rather than "the integration's reload path is broken."

Thanks for maintaining this — happy to iterate on the PR if you'd like the changes structured differently.