### PR TITLE
fix(manifest): align dacite pin with requirements.txt (1.9.2)

### DIFF
--- a/custom_components/generac/manifest.json
+++ b/custom_components/generac/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/binarydev/ha-generac",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/binarydev/ha-generac/issues",
-  "requirements": ["dacite==1.8.1", "cryptography>=41"],
+  "requirements": ["dacite==1.9.2", "cryptography>=41"],
   "version": "0.5.3"
 }


### PR DESCRIPTION
`manifest.json` is what HA installs for users; `requirements.txt` is what CI tests against. The two diverged (`1.8.1` vs `1.9.2`) in 8199aba, so the suite validates a different dacite than production installs run. One-line alignment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
