### PR TITLE
fix(auth): treat non-standard 403 invalid_grant as reauth instead of a silent failure

### DIFF
--- a/custom_components/generac/auth.py
+++ b/custom_components/generac/auth.py
@@ -1003,7 +1003,23 @@ class GeneracAuth:
                     )
             return
 
-        if status == 400 and payload.get("error") == "invalid_grant":
+        # OAuth2 (RFC 6749 §5.2) mandates HTTP 400 for invalid_grant, but
+        # Generac's IdP returns it as 403. Trust the OAuth `error` field over
+        # the HTTP status so an invalidated refresh token always triggers HA's
+        # reauth flow (InvalidGrantError -> ConfigEntryAuthFailed) instead of
+        # falling through to a generic RuntimeError that silently freezes every
+        # entity as "unavailable" with no user-facing prompt to re-login.
+        if payload.get("error") == "invalid_grant":
             raise InvalidGrantError(payload.get("error_description", "invalid_grant"))
+
+        # Any other outright rejection from the token endpoint (401/403) means
+        # our grant/credentials are no longer accepted — an auth failure, not a
+        # transient outage. Surface it as reauth rather than looping on
+        # UpdateFailed forever. Transient 5xx / network errors fall through to
+        # RuntimeError below so the coordinator retries instead of prompting.
+        if status in (401, 403):
+            raise InvalidGrantError(
+                f"token endpoint rejected credentials ({status}): {payload}"
+            )
 
         raise RuntimeError(f"token refresh failed: {status} {payload}")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -135,9 +135,54 @@ async def test_refresh_invalid_grant_raises():
         await auth._refresh()
 
 
-# ---------------------------------------------------------------------------
-# P1: Auth0 ULP form-parser error code mapping
-# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_refresh_invalid_grant_403_raises():
+    """Generac returns invalid_grant with HTTP 403, not the RFC-standard 400.
+
+    Regression: the old `status == 400` guard let this fall through to a
+    generic RuntimeError, so the coordinator hit its catch-all ("Unexpected
+    error refreshing Generac data") instead of ConfigEntryAuthFailed — every
+    entity went unavailable with no reauth prompt.
+    """
+    auth = _make_auth(refresh_token="rt-REVOKED")
+    auth._session.post = MagicMock(
+        return_value=_acm(
+            _token_resp(
+                403,
+                {
+                    "error": "invalid_grant",
+                    "error_description": "Unknown or invalid refresh token.",
+                },
+            )
+        )
+    )
+
+    with pytest.raises(InvalidGrantError):
+        await auth._refresh()
+
+
+@pytest.mark.asyncio
+async def test_refresh_bare_403_raises_invalid_grant():
+    """A 401/403 with no OAuth error body is still an auth failure -> reauth."""
+    auth = _make_auth(refresh_token="rt-REVOKED")
+    auth._session.post = MagicMock(
+        return_value=_acm(_token_resp(403, {"raw": "Forbidden"}))
+    )
+
+    with pytest.raises(InvalidGrantError):
+        await auth._refresh()
+
+
+@pytest.mark.asyncio
+async def test_refresh_transient_5xx_raises_runtime_error():
+    """Transient 5xx stays a RuntimeError (-> UpdateFailed -> retry), not reauth."""
+    auth = _make_auth(refresh_token="rt-OLD")
+    auth._session.post = MagicMock(
+        return_value=_acm(_token_resp(500, {"error": "server_error"}))
+    )
+
+    with pytest.raises(RuntimeError):
+        await auth._refresh()
 
 
 def _ulp_error_resp(status: int, code: str | None):


### PR DESCRIPTION
## Problem

When a Generac refresh token is invalidated, every entity goes `unavailable` with **no user-facing prompt** to re-login. The log just spams `Unexpected error refreshing Generac data`, and the config entry stays `loaded`, so there's no reauth flow and no Repairs card — the integration is silently broken until you notice the stale data yourself.

## Root cause: Generac returns a non-standard HTTP status

[RFC 6749 §5.2](https://datatracker.ietf.org/doc/html/rfc6749#section-5.2) mandates that an `invalid_grant` error be returned with **HTTP 400**. Generac's Auth0/Apigee token endpoint instead returns it as **HTTP 403**:

```
token refresh failed: 403 {'error': 'invalid_grant',
  'error_description': 'Unknown or invalid refresh token.'}
```

The refresh handler only classified this as an auth failure on the *spec-compliant* status:

```python
if status == 400 and payload.get("error") == "invalid_grant":
```

Because Generac sends **403**, this check is skipped and execution falls through to a generic `RuntimeError`. The coordinator catches that as a plain `Exception` → `UpdateFailed` (never `ConfigEntryAuthFailed`), so HA never triggers the reauth flow.

## Fix

Don't rely on Generac honoring the OAuth status-code convention. Trust the OAuth `error` field over the HTTP status:

- Any `invalid_grant` payload → `InvalidGrantError` **regardless of HTTP status**.
- Any bare **401/403** from the token endpoint → `InvalidGrantError` (a rejected grant is an auth failure, not a transient outage), so we don't loop on `UpdateFailed` forever.
- **5xx / network** errors still raise `RuntimeError` → `UpdateFailed` for transient retry.

`InvalidGrantError` is already mapped to `ConfigEntryAuthFailed` in the coordinator, which starts HA's reauth flow.

## Tests

Adds regression tests: 403 `invalid_grant`, a bare 403 (no OAuth error body), and a transient 5xx (still `RuntimeError`). `pytest tests/test_auth.py` → 14 passed.

## Validation

Deployed to a live HA instance that had an already-invalidated refresh token. After restart: entry → `setup_error`, a **reauth flow starts** (`step: reauth_confirm`), a **Repairs card appears** (`config_entry_reauth_generac_…`), and the log now reads `Generac auth rejected, requesting reauth` instead of `Unexpected error refreshing Generac data`.

Complementary to #286 (which fixed the entry not reloading *after* a successful reauth); this fixes the reauth prompt not *appearing* in the first place.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
